### PR TITLE
Watch impresso images, pull and restart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ config
 *.zip
 config_preprod
 config_prod
+config_dev
 .DS_Store
 .env

--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ Running in production (detached mode), check the contents of your `.env` file if
 docker-compose -p impresso up -d
 ```
 
+Running in staging (detached mode), with the watchtower service that updates the images every 5 minutes:
+
+```shell
+docker-compose -f docker-compose.yml -f docker-compose.watcher.yml -p impresso up -d
+```
+
+
+```shell
+
 Reading logs in production:
 ```shell
 docker-compose -p impresso logs -f

--- a/docker-compose.watcher.yml
+++ b/docker-compose.watcher.yml
@@ -1,0 +1,11 @@
+version: '3.7'
+
+services:
+  watchtower:
+    image: containrrr/watchtower
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock # So that Watchtower can update other containers
+      - -v $HOME/.docker/config.json:/config.json # Get Docker Hub credentials from here
+    # Check every 5 minutes
+    command: --interval 300 impresso-public-api impresso-middle-layer impresso-frontend
+    restart: always

--- a/docker-compose.watcher.yml
+++ b/docker-compose.watcher.yml
@@ -6,6 +6,10 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock # So that Watchtower can update other containers
       - -v $HOME/.docker/config.json:/config.json # Get Docker Hub credentials from here
-    # Check every 5 minutes
-    command: --interval 300 impresso-public-api impresso-middle-layer impresso-frontend
+    command: impresso/impresso-middle-layer impresso/impresso-user-admin impresso/impresso-frontend
     restart: always
+    environment:
+      WATCHTOWER_POLL_INTERVAL: 300 # Check every 5 minutes
+      WATCHTOWER_CLEANUP: true # remove old images after updating
+      #WATCHTOWER_NOTIFICATIONS: 'slack'
+      #WATCHTOWER_NOTIFICATION_SLACK_HOOK_URL='...'


### PR DESCRIPTION
Adds a watchtower service for staging deployment that watches changes to impresso images in Docker Hub, downloads and restarts the services when they change.

Watchtower uses HEAD requests to Docker Hub that do not count towards pull quota.