### PR TITLE
Add development Solr server configuration

### DIFF
--- a/.env.nosecret-prod
+++ b/.env.nosecret-prod
@@ -10,6 +10,7 @@ IMPRESSO_DATALAB_TAG=v3.4.0
 
 # URLs
 SOLR_BASE_URL=https://solrcloud-prod-dhlab.epfl.ch/solr
+SOLR_DEV_BASE_URL=https://solrcloud-dev-dhlab.epfl.ch/solr
 DB_HOSTNAME=mysql-impresso.epfl.ch
 DB_DATABASE=impresso
 

--- a/config_prod/impresso-middle-layer.json
+++ b/config_prod/impresso-middle-layer.json
@@ -90,6 +90,20 @@
             "password": "${SOLR_WRITER_PASSWORD}"
           }
         }
+      },
+      {
+        "id": "development",
+        "baseUrl": "${SOLR_DEV_BASE_URL}",
+        "auth": {
+          "read": {
+            "username": "${SOLR_READER_USERNAME}",
+            "password": "${SOLR_READER_PASSWORD}"
+          },
+          "write": {
+            "username": "${SOLR_WRITER_USERNAME}",
+            "password": "${SOLR_WRITER_PASSWORD}"
+          }
+        }
       }
     ],
     "namespaces": [
@@ -105,8 +119,8 @@
       },
       {
         "namespaceId": "images",
-        "serverId": "default",
-        "index": "03_impresso_images",
+        "serverId": "development",
+        "index": "03_impresso_images_test",
         "schemaVersion": "v2"
       },
       {
@@ -152,7 +166,10 @@
     ]
   },
   "features": {
-    "barista": { "enabled": false, "url": "http://impresso-barista:8000/chat/stream" }
+    "barista": {
+      "enabled": false,
+      "url": "http://impresso-barista:8000/chat/stream"
+    }
   },
   "callbackUrls": {
     "passwordReset": "https://impresso-project.ch/app/password-reset"


### PR DESCRIPTION
Introduces SOLR_DEV_BASE_URL to the environment and adds a 'development' Solr server entry in impresso-middle-layer config. Updates the 'images' namespace to use the development server and test index for improved separation of production and development resources.